### PR TITLE
roomleader available

### DIFF
--- a/config/config-example.js
+++ b/config/config-example.js
@@ -245,7 +245,6 @@ exports.grouplist = [
 		rangeban: true,
 		potd: true,
 		disableladder: true,
-		globalonly: true,
 		tournamentsmanagement: true
 	},
 	{
@@ -254,6 +253,7 @@ exports.grouplist = [
 		name: "Room Owner",
 		inherit: '@',
 		jurisdiction: 'u',
+		roomleader: true,
 		roommod: true,
 		roomdriver: true,
 		declare: true,


### PR DESCRIPTION
If we're gonna have leagues, often having roomleader is useful and nice to have, by deleting the line in leader: "globalonly: true," it enables that, I also made roomowners able to promote to roomleader.