### PR TITLE
fixed .ps-room.ps-room-opaque's color to black

### DIFF
--- a/config/custom.css
+++ b/config/custom.css
@@ -171,7 +171,7 @@ a.button.notifying.closable:hover {
 }
 .ps-room.ps-room-opaque {
     background: rgba(240, 240, 240, 0.8);
-    color: #FFF;
+    color: #000;
 }
 div.trainer > strong {
     color: #323841;


### PR DESCRIPTION
so that the "Waiting for oponent text is visible: http://prntscr.com/6pgw8t ~ http://prntscr.com/6pgwka