### PR TITLE
Rewrite /away and /back, "request" is not a module

### DIFF
--- a/components.js
+++ b/components.js
@@ -14,119 +14,116 @@
 
 var fs = require("fs");
     path = require("path"),
-    http = require("http"),
-    request = require('request');
+    http = require("http");
+
+var bubbleLetterMap = new Map([
+	['a', '\u24D0'], ['b', '\u24D1'], ['c', '\u24D2'], ['d', '\u24D3'], ['e', '\u24D4'], ['f', '\u24D5'], ['g', '\u24D6'], ['h', '\u24D7'], ['i', '\u24D8'], ['j', '\u24D9'], ['k', '\u24DA'], ['l', '\u24DB'], ['m', '\u24DC'],
+	['n', '\u24DD'], ['o', '\u24DE'], ['p', '\u24DF'], ['q', '\u24E0'], ['r', '\u24E1'], ['s', '\u24E2'], ['t', '\u24E3'], ['u', '\u24E4'], ['v', '\u24E5'], ['w', '\u24E6'], ['x', '\u24E7'], ['y', '\u24E8'], ['z', '\u24E9'],
+	['A', '\u24B6'], ['B', '\u24B7'], ['C', '\u24B8'], ['D', '\u24B9'], ['E', '\u24BA'], ['F', '\u24BB'], ['G', '\u24BC'], ['H', '\u24BD'], ['I', '\u24BE'], ['J', '\u24BF'], ['K', '\u24C0'], ['L', '\u24C1'], ['M', '\u24C2'],
+	['N', '\u24C3'], ['O', '\u24C4'], ['P', '\u24C5'], ['Q', '\u24C6'], ['R', '\u24C7'], ['S', '\u24C8'], ['T', '\u24C9'], ['U', '\u24CA'], ['V', '\u24CB'], ['W', '\u24CC'], ['X', '\u24CD'], ['Y', '\u24CE'], ['Z', '\u24CF']
+]);
+var asciiMap = new Map([
+	['\u24D0', 'a'], ['\u24D1', 'b'], ['\u24D2', 'c'], ['\u24D3', 'd'], ['\u24D4', 'e'], ['\u24D5', 'f'], ['\u24D6', 'g'], ['\u24D7', 'h'], ['\u24D8', 'i'], ['\u24D9', 'j'], ['\u24DA', 'k'], ['\u24DB', 'l'], ['\u24DC', 'm'],
+	['\u24DD', 'n'], ['\u24DE', 'o'], ['\u24DF', 'p'], ['\u24E0', 'q'], ['\u24E1', 'r'], ['\u24E2', 's'], ['\u24E3', 't'], ['\u24E4', 'u'], ['\u24E5', 'v'], ['\u24E6', 'w'], ['\u24E7', 'x'], ['\u24E8', 'y'], ['\u24E9', 'z'],
+	['\u24B6', 'A'], ['\u24B7', 'B'], ['\u24B8', 'C'], ['\u24B9', 'D'], ['\u24BA', 'E'], ['\u24BB', 'F'], ['\u24BC', 'G'], ['\u24BD', 'H'], ['\u24BE', 'I'], ['\u24BF', 'J'], ['\u24C0', 'K'], ['\u24C1', 'L'], ['\u24C2', 'M'],
+	['\u24C3', 'N'], ['\u24C4', 'O'], ['\u24C5', 'P'], ['\u24C6', 'Q'], ['\u24C7', 'R'], ['\u24C8', 'S'], ['\u24C9', 'T'], ['\u24CA', 'U'], ['\u24CB', 'V'], ['\u24CC', 'W'], ['\u24CD', 'X'], ['\u24CE', 'Y'], ['\u24CF', 'Z']
+]);
+
+function parseStatus(text, encoding) {
+	if (encoding) {
+		text = text.split('').map(function(char) {
+			return bubbleLetterMap.get(char);
+		}).join('');
+	} else {
+		text = text.split('').map(function(char) {
+			return asciiMap.get(char);
+		}).join('');
+	}
+	return text;
+}
 
 var components = exports.components = {
 
-       eating: 'away',
-       gaming: 'away',
-       sleep: 'away',
-       work: 'away',
-       working: 'away',
-       sleeping: 'away',
-       busy: 'away',
-       afk: 'away',
-       fap: 'away',
-       fapping: 'away',
-       nerd: 'away',
-       nerding: 'away',
-       away: function(target, room, user, connection, cmd) {
-            // unicode away message idea by Siiilver
-            var t = 'ⒶⓌⒶⓎ';
-            var t2 = 'Away';
-            switch (cmd) {
-           case 'busy':
-t = 'ⒷⓊⓈⓎ';
-t2 = 'Busy';
-break;
-case 'sleeping':
-t = 'ⓈⓁⒺⒺⓅⒾⓃⒼ';
-t2 = 'Sleeping';
-break;
-case 'nerd':
-t = 'ⓃⒺⓇⒹⒾⓃⒼ';
-t2 = 'Nerding';
-break;
-case 'nerding':
-t = 'ⓃⒺⓇⒹⒾⓃⒼ';
-t2 = 'Nerding';
-break;
-case 'sleep':
-t = 'ⓈⓁⒺⒺⓅⒾⓃⒼ';
-t2 = 'Sleeping';
-break;
-case 'gaming':
-t = 'ⒼⒶⓂⒾⓃⒼ';
-t2 = 'Gaming';
-break;
-case 'working':
-t = 'ⓌⓄⓇⓀⒾⓃⒼ';
-t2 = 'Working';
-break;
-case 'work':
-t = 'ⓌⓄⓇⓀⒾⓃⒼ';
-t2 = 'Working';
-break;
-case 'eating':
-t = 'ⒺⒶⓉⒾⓃⒼ';
-t2 = 'Eating';
-break;
-default:
-t = 'ⒶⓌⒶⓎ'
-t2 = 'Away';
-break;
-}
+	afk: function (target, room, user) {
+		this.parse('/away AFK', room, user);
+	},
+	busy: function (target, room, user) {
+		this.parse('/away BUSY', room, user);
+	},
+	work: function (target, room, user) {
+		this.parse('/away WORK', room, user);
+	},
+	working: function (target, room, user) {
+		this.parse('/away WORKING', room, user);
+	},
+	eating: function (target, room, user) {
+		this.parse('/away EATING', room, user);
+	},
+	gaming: function (target, room, user) {
+		this.parse('/away GAMING', room, user);
+	},
+	sleep: function (target, room, user) {
+		this.parse('/away SLEEP', room, user);
+	},
+	sleeping: function (target, room, user) {
+		this.parse('/away SLEEPING', room, user);
+	},
+	fap: function (target, room, user) {
+		this.parse('/away FAP', room, user);
+	},
+	fapping: function (target, room, user) {
+		this.parse('/away FAPPING', room, user);
+	},
+	nerd: function (target, room, user) {
+		this.parse('/away NERD', room, user);
+	},
+	nerding: function (target, room, user) {
+		this.parse('/away NERDING', room, user);
+	},
+	away: function(target, room, user) {
+		if (!user.isAway && user.name.length > 15) return this.sendReply('Your username is too long for any kind of use of this command.');
 
-if (user.name.length > 18) return this.sendReply('Your username exceeds the length limit.');
+		target = target ? target.replace(/[^a-zA-Z0-9]/g, '') : 'AWAY';
+		var statusLen = target.length;
+		if (statusLen > 14) return this.sendReply('Your away status should be short and to-the-point, not a dissertation on why you are away.');
+		if (user.name.length + statusLen > 15) return this.sendReply('"' + target + '" is too long to use as your away status.');
 
-if (!user.isAway) {
-user.originalName = user.name;
-var awayName = user.name + ' - '+t;
-//delete the user object with the new name in case it exists - if it does it can cause issues with forceRename
-delete Users.get(awayName);
-user.forceRename(awayName, undefined, true);
+		var status = parseStatus(target, true);
+		if (user.isAway && user.substr(-statusLen) === target) return this.sendReply('Your away status is already set to ' + target + '.');
 
-if (user.can('lock')) this.add('|raw|-- <b><font color="#088cc7">' + user.originalName +'</font color></b> is now '+t2.toLowerCase()+'. '+ (target ? " (" + escapeHTML(target) + ")" : ""));
+		// forcerename any possible impersonators
+		var targetUser = Users.getExact(user.userid + target);
+		if (targetUser && targetUser !== user && targetUser.name === user.name + ' - ' + target) {
+			targetUser.resetName();
+			targetUser.send('|nametaken||Your name conflicts with ' + user.name + (user.name.substr(-1) === 's' ? '\'' : '\'s') + ' new away status.');
+		}
 
-user.isAway = true;
-}
-else {
-return this.sendReply('You are already set as a form of away, type /back if you are now back.');
-}
+		var newName = user.name + ' - ' + status;
+		user.forceRename(newName, user.registered);
+		user.updateIdentity();
+		user.isAway = true;
+		if (user.can('lock', null, room)) this.add('|raw|-- <font color="#088CC7"><strong>' + Tools.escapeHTML(user.name) + '</strong></font> is now ' + target.toLowerCase() + '.');
+	},
+	
+	back: function (target, room, user) {
+		if (!user.isAway) return this.sendReply('You are not set as away.');
+		user.isAway = false;
 
-user.updateIdentity();
-},
+		var newName = user.name;
+		var statusIdx = newName.search(/\s\-\s[\u24B6-\u24E9]+$/);
+		if (statusIdx < 0) {
+			user.isAway = false;
+			if (user.can('lock', null, room)) this.add('|raw|-- <font color="#088CC7"><strong>' + Tools.escapeHTML(user.name) + '</strong></font> is no longer away.');
+			return false;
+		}
 
-back: function(target, room, user, connection) {
-
-if (user.isAway) {
-if (user.name === user.originalName) {
-user.isAway = false;
-return this.sendReply('Your name has been left unaltered and no longer marked as away.');
-}
-
-var newName = user.originalName;
-
-//delete the user object with the new name in case it exists - if it does it can cause issues with forceRename
-delete Users.get(newName);
-
-user.forceRename(newName, undefined, true);
-
-//user will be authenticated
-user.authenticated = true;
-
-if (user.can('lock')) this.add('|raw|-- <b><font color="#088cc7">' + newName + '</font color></b> is no longer away.');
-
-user.originalName = '';
-user.isAway = false;
-}
-else {
-return this.sendReply('You are not set as away.');
-}
-
-user.updateIdentity();
-},
+		var status = parseStatus(newName.substr(statusIdx + 3), false);
+		newName = newName.substr(0, statusIdx);
+		user.forceRename(newName, user.registered);
+		user.updateIdentity();
+		user.isAway = false;
+		if (user.can('lock', null, room)) this.add('|raw|-- <font color="#088CC7"><strong>' + Tools.escapeHTML(newName) + '</strong></font> is no longer ' + Tools.escapeHTML(status) + '.');
+	},
 
 	spam: 'spamroom',
 	spamroom: function (target, room, user) {
@@ -511,7 +508,7 @@ user.updateIdentity();
                 }
             }
         }
-        request(options, callback);
+        http.request(options, callback);
     },
 
     def: 'define',
@@ -546,7 +543,7 @@ user.updateIdentity();
                 }
             }
         }
-        request(options, callback);
+        http.request(options, callback);
     },
 
     /*********************************************************


### PR DESCRIPTION
Deleting the user object found creates a memory leak because the
reference to the deleted user object is kept after forcerenaming the
user. This command can now be used to add any kind of away status, so
long as it fits in the username.

"request" is no longer required, and instances where the "module" is
used are replaced with http.request.