### PR TITLE
custom.css: added an img next to message-pm

### DIFF
--- a/config/custom.css
+++ b/config/custom.css
@@ -267,6 +267,8 @@ body {
 
   span.message-pm {
       color: #00A0A0;
+      padding: 0px 25px 0px 0px;
+      background: url("http://www.blastyak.net/img/mail.png") top right no-repeat;
   }
 
   div.chat small {


### PR DESCRIPTION
Added a little mail icon next to the message-pm that appears in chat-log to add some stuff here, that aren't on any other servers.
Plus it looks pretty cute: http://prntscr.com/71sgfh